### PR TITLE
chore: update resume URL in config

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 const CONFIG = {
-    RESUME_URL: 'https://lucasvieiras.github.io/resume/Lucas_Vieira_CV.pdf'
+    RESUME_URL: 'https://drive.google.com/file/d/1BQFUU1A4y_HOoDUbbcp7lR8DmlDnFP-6/view?usp=sharing'
 };
 
 function downloadResume() {    


### PR DESCRIPTION
Changed the RESUME_URL in CONFIG to point to a Google Drive link instead of the previous GitHub Pages URL.